### PR TITLE
fix to port on security group

### DIFF
--- a/example.tf
+++ b/example.tf
@@ -24,7 +24,7 @@ resource "aws_security_group" "allow_all" {
 
   ingress {
       from_port = 0
-      to_port = 65535
+      to_port = 0
       protocol = "-1"
       cidr_blocks = ["0.0.0.0/0"]
   }


### PR DESCRIPTION
Fixes this error:

```
* 1 error(s) occurred:

* from_port (0) and to_port (65535) must both be 0 to use the the 'ALL' "-1" protocol!
```

@pearkes 