### PR TITLE
update AMI id

### DIFF
--- a/example.tf
+++ b/example.tf
@@ -5,7 +5,7 @@ resource "aws_instance" "main" {
     instance_type = "t2.micro"
 
     # Trusty 14.04
-    ami = "ami-2a734c42"
+    ami = "ami-fce3c696"
 
     # This will create 1 instances
     count = 1


### PR DESCRIPTION
The AMI id fails on install with the following error:

```
Error applying plan:

1 error(s) occurred:

* aws_instance.main: Error launching source instance: InvalidAMIID.NotFound: The image id 'ami-2a734c42' does not exist
	status code: 400, request id: 

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```
It should use a currently available AMI id which is free tier eligable