### PR TITLE
update example config to use vpc_security_group_ids

### DIFF
--- a/example.tf
+++ b/example.tf
@@ -2,31 +2,31 @@
 # Instance
 #--------------------------------------------------------------
 resource "aws_instance" "main" {
-    instance_type = "t2.micro"
+  instance_type = "t2.micro"
 
-    # Trusty 14.04
-    ami = "ami-fce3c696"
+  # Trusty 14.04
+  ami = "ami-fce3c696"
 
-    # This will create 1 instances
-    count = 1
+  # This will create 1 instances
+  count = 1
 
-    subnet_id = "${aws_subnet.main.id}"
-    security_groups = ["${aws_security_group.allow_all.id}"]
+  subnet_id              = "${aws_subnet.main.id}"
+  vpc_security_group_ids = ["${aws_security_group.allow_all.id}"]
 }
 
 #--------------------------------------------------------------
 # Security Group
 #--------------------------------------------------------------
 resource "aws_security_group" "allow_all" {
-  name = "allow_all"
+  name        = "allow_all"
   description = "Allow all inbound traffic"
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id      = "${aws_vpc.main.id}"
 
   ingress {
-      from_port = 0
-      to_port = 0
-      protocol = "-1"
-      cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
@@ -34,29 +34,30 @@ resource "aws_security_group" "allow_all" {
 # VPC
 #--------------------------------------------------------------
 resource "aws_vpc" "main" {
-    cidr_block = "172.31.0.0/16"
-    enable_dns_hostnames = true
+  cidr_block           = "172.31.0.0/16"
+  enable_dns_hostnames = true
 }
 
 resource "aws_subnet" "main" {
-    vpc_id = "${aws_vpc.main.id}"
-    cidr_block = "172.31.0.0/20"
-    map_public_ip_on_launch = true
+  vpc_id                  = "${aws_vpc.main.id}"
+  cidr_block              = "172.31.0.0/20"
+  map_public_ip_on_launch = true
 }
 
 resource "aws_internet_gateway" "gw" {
-    vpc_id = "${aws_vpc.main.id}"
+  vpc_id = "${aws_vpc.main.id}"
 }
 
 resource "aws_route_table" "r" {
-    vpc_id = "${aws_vpc.main.id}"
-    route {
-        cidr_block = "0.0.0.0/0"
-        gateway_id = "${aws_internet_gateway.gw.id}"
-    }
+  vpc_id = "${aws_vpc.main.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.gw.id}"
+  }
 }
 
 resource "aws_main_route_table_association" "a" {
-    vpc_id = "${aws_vpc.main.id}"
-    route_table_id = "${aws_route_table.r.id}"
+  vpc_id         = "${aws_vpc.main.id}"
+  route_table_id = "${aws_route_table.r.id}"
 }


### PR DESCRIPTION
Updates the `example.tf` config to use `vpc_security_group_ids` instead of `security_groups`. Terraform v0.6.16 has a regression that caused `security_groups` and `vpc_security_group_ids` to _not_ be interchangeable as they were in v0.6.15 and before. Right now, after successfully applying this plan an immediate follow up plan will show a diff and want to recreate the instance forever until this is changed in the config. 

In v0.7.0 we will likely make them not interchangeable but we'll so explicitly and mention it in the change long. 

There's a lot of diff here because my editor automatically ran this through `hclfmt`, but the only line I changed is this:

```diff
-    security_groups = ["${aws_security_group.allow_all.id}"]
+  vpc_security_group_ids = ["${aws_security_group.allow_all.id}"]
```


Backstory: https://github.com/hashicorp/terraform/issues/6416#issuecomment-219145065